### PR TITLE
Switch Get Started to use cleanlab_tlm

### DIFF
--- a/TLM-intro/Real_time_Eval_for_every_LLM_response_with_Cleanlab_TLM.ipynb
+++ b/TLM-intro/Real_time_Eval_for_every_LLM_response_with_Cleanlab_TLM.ipynb
@@ -17,8 +17,19 @@
       },
       "outputs": [],
       "source": [
-        "#@title Install Cleanlab\n",
-        "%pip install --upgrade cleanlab-studio"
+        "#@title Install Cleanlab TLM\n",
+        "%pip install --upgrade cleanlab-tlm"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "# Set your API key\n",
+        "import os\n",
+        "os.environ[\"CLEANLAB_TLM_API_KEY\"] = \"<API key>\"  # Get your API key from: https://tlm.cleanlab.ai/"
       ]
     },
     {
@@ -63,11 +74,9 @@
         }
       ],
       "source": [
-        "from cleanlab_studio import Studio\n",
+        "from cleanlab_tlm import TLM\n",
         "\n",
-        "studio = Studio(\"<YOUR_API_KEY>\")  # Get your API key from https://tlm.cleanlab.ai\n",
-        "\n",
-        "tlm = studio.TLM(options={\"log\": [\"explanation\"], \"model\": \"gpt-4o-mini\"}) # supports GPT, Claude, etc\n",
+        "tlm = TLM(options={\"log\": [\"explanation\"], \"model\": \"gpt-4o-mini\"}) # supports GPT, Claude, etc\n",
         "\n",
         "# Use TLM like GPT (with more accurate results). Returns response, trustworthiness score, explanation\n",
         "out = tlm.prompt(\"What's the third month of the year alphabetically?\")\n",


### PR DESCRIPTION
Use the new `cleanlab-tlm` python client. the TLM modules within `cleanlab-studio` will soon be deprecated